### PR TITLE
Add prompt symbol.

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -133,9 +133,12 @@ prompt_pure_preprompt_render() {
     preprompt+=$'\n'
   fi
 
+	local symbol_color="%(?.${PURE_PROMPT_SYMBOL_COLOR:-magenta}.red)"
 
-  # begin with path, colored by vim-mode
-  preprompt+="%B%F{$STATUS_COLOR}%c%f%b"
+	# begin with symbol, colored by previous command exit code
+	preprompt+="%F{$symbol_color}${PURE_PROMPT_SYMBOL:-❯}%f "
+	# directory, colored by vim status
+	preprompt+="%B%F{$STATUS_COLOR}%c%f%b"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows
@@ -144,8 +147,6 @@ prompt_pure_preprompt_render() {
 	preprompt+=$prompt_pure_username
 	# execution time
 	preprompt+="%B%F{242}${prompt_pure_cmd_exec_time}%f%b"
-	# show indicator if previous command failed
-	preprompt+="%(?.. ⚠️️ )"
 
 	preprompt+=" "
 


### PR DESCRIPTION
I've been playing around with this for the past week and feel like it's an improvement, and it makes this fork closer to the original Pure which is nice. This also replaces the emoji status indicator by coloring the prompt symbol instead, [since emoji cause display issues on some systems](https://github.com/DFurnes/purer/issues/1).

![screen shot 2017-04-26 at 12 07 05 am](https://cloud.githubusercontent.com/assets/583202/25417799/b49fd46e-2a14-11e7-940a-8e9d7298fab9.png)