### PR TITLE
Document color-names / color-codes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Purer supports customization using [Pure's environment variables](https://github
 
 ### `PURE_PROMPT_SYMBOL_COLOR`
 
-Defines the prompt symbol color. The default value is `magenta`.
+Defines the prompt symbol color. The default value is `magenta`; you can use any [colour name](https://wiki.archlinux.org/index.php/Zsh#Colors) or [numeric colour code](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg) (see `zshzle(1)` section [Character Highlighting](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting).)
 
 ## License
 


### PR DESCRIPTION
Copied the text and links from the Arch Linux wiki (as that was the most thorough documentation I could find; zsh's own is a bit subpar here.)