### PR TITLE
Make path formatting configurable

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -139,7 +139,7 @@ prompt_pure_preprompt_render() {
   fi
 
 	local symbol_color="%(?.${PURE_PROMPT_SYMBOL_COLOR:-magenta}.red)"
-    local path_formatting="${PURE_PROMPT_PATH_FORMATTING:-%c}"
+	local path_formatting="${PURE_PROMPT_PATH_FORMATTING:-%c}"
 
 	# show virtual env
 	preprompt+="%(12V.%F{242}%12v%f .)"

--- a/pure.zsh
+++ b/pure.zsh
@@ -139,14 +139,14 @@ prompt_pure_preprompt_render() {
   fi
 
 	local symbol_color="%(?.${PURE_PROMPT_SYMBOL_COLOR:-magenta}.red)"
-    local path_formatting="%${PURE_PROMPT_PATH_FORMATTING:c}"
+    local path_formatting="${PURE_PROMPT_PATH_FORMATTING:-%c}"
 
 	# show virtual env
 	preprompt+="%(12V.%F{242}%12v%f .)"
 	# begin with symbol, colored by previous command exit code
 	preprompt+="%F{$symbol_color}${PURE_PROMPT_SYMBOL:-❯}%f "
 	# directory, colored by vim status
-	preprompt+="%B%F{$STATUS_COLOR}{$path_formatting}%f%b"
+	preprompt+="%B%F{$STATUS_COLOR}$path_formatting%f%b"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows

--- a/pure.zsh
+++ b/pure.zsh
@@ -139,13 +139,14 @@ prompt_pure_preprompt_render() {
   fi
 
 	local symbol_color="%(?.${PURE_PROMPT_SYMBOL_COLOR:-magenta}.red)"
+    local path_formatting="%${PURE_PROMPT_PATH_FORMATTING:c}"
 
 	# show virtual env
 	preprompt+="%(12V.%F{242}%12v%f .)"
 	# begin with symbol, colored by previous command exit code
 	preprompt+="%F{$symbol_color}${PURE_PROMPT_SYMBOL:-❯}%f "
 	# directory, colored by vim status
-	preprompt+="%B%F{$STATUS_COLOR}%c%f%b"
+	preprompt+="%B%F{$STATUS_COLOR}{$path_formatting}%f%b"
 	# git info
 	preprompt+="%F{$git_color}${vcs_info_msg_0_}${prompt_pure_git_dirty}%f"
 	# git pull/push arrows

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,11 @@ Purer supports customization using [Pure's environment variables](https://github
 
 Defines the prompt symbol color. The default value is `magenta`; you can use any [colour name](https://wiki.archlinux.org/index.php/Zsh#Colors) or [numeric colour code](https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg) (see `zshzle(1)` section [Character Highlighting](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting).)
 
+
+### `PURE_PROMPT_PATH_FORMATTING`
+
+Defines how to display the path. Default value: `%c`. See [Prompt Expansion](http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html) for more.
+
 ## License
 
 Purer MIT © [David Furnes](http://dfurnes.com) <br/>


### PR DESCRIPTION
I love this prompt, but I was missing the option to use for example `%~` for the path formatting.

PR adds a check for `PURE_PROMPT_PATH_FORMATTING`.
Now users can define their preferred path formatting via 
```sh
export PURE_PROMPT_PATH_FORMATTING="%~"
```
for example.
If `PURE_PROMPT_PATH_FORMATTING` is not defined it sticks to the current default `%c`.