### PR TITLE
Display number of suspended jobs

### DIFF
--- a/pure.zsh
+++ b/pure.zsh
@@ -140,6 +140,8 @@ prompt_pure_preprompt_render() {
 
 	local symbol_color="%(?.${PURE_PROMPT_SYMBOL_COLOR:-magenta}.red)"
 
+	# show background jobs
+	preprompt+="%(1j.%j.) "
 	# show virtual env
 	preprompt+="%(12V.%F{242}%12v%f .)"
 	# begin with symbol, colored by previous command exit code


### PR DESCRIPTION
Adds the number of suspended jobs in front of the prompt, or nothing if there are none.

Example:
2 suspended jobs
`2 ❯ ~`